### PR TITLE
chore: upgrade action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
     is-new-package:
         description: 'Whether repo package has not been published yet (`"true"` or `"false"`)'
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'dist/index.js'
 branding:
     icon: 'loader'


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026. This upgrades the action runtime from `node20` to `node24`.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/